### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 </tr>
 </table>
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/imprvhub-mcp-rss-aggregator).
+
 ## Features
 
 - Read articles from your favorite RSS feeds directly in Claude Desktop


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/imprvhub-mcp-rss-aggregator)